### PR TITLE
Temporary dupe fix.

### DIFF
--- a/src/main/java/nl/rutgerkok/betterenderchest/eventhandler/BetterEnderSlotsHandler.java
+++ b/src/main/java/nl/rutgerkok/betterenderchest/eventhandler/BetterEnderSlotsHandler.java
@@ -38,11 +38,7 @@ public class BetterEnderSlotsHandler implements Listener {
             return;
         }
 
-        if (event.isShiftClick()) {
-            handleDisabledSlotsShiftClick(event);
-        } else {
-            handleDisabledSlotsNormalClick(event);
-        }
+        handleDisabledSlotsNormalClick(event);
 
     }
 


### PR DESCRIPTION
This is causing dupes when entering stacked spawners/stacked potions into enderchests. You can turn 3 spawners into 1000.
