### PR TITLE
Fix duplication bug caused by oversized item stacks

### DIFF
--- a/src/main/java/nl/rutgerkok/betterenderchest/eventhandler/BetterEnderSlotsHandler.java
+++ b/src/main/java/nl/rutgerkok/betterenderchest/eventhandler/BetterEnderSlotsHandler.java
@@ -134,6 +134,8 @@ public class BetterEnderSlotsHandler implements Listener {
 
             // Calculate how many will fit
             int itemsToAdd = Math.min(inventory.getMaxStackSize(), inSlot.getMaxStackSize()) - inSlot.getAmount();
+            
+            itemsToAdd = Math.max(itemsToAdd, 0);
             // Limit that by how many we actually have
             itemsToAdd = Math.min(adding.getAmount(), itemsToAdd);
 


### PR DESCRIPTION
Fix for #23 

The problem described in #23 was caused by item stacks with a larger amount than expected by getMaxStackSize(). This caused a negative amount of items to be added to the chest which than substracted a negative amount of items from the clicked stack, thus adding items that shouldn't exist.